### PR TITLE
Create global contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+Thank you for taking an interest in contributing to Aqua's open source projects!
+
+## Issues
+
+- Feel free to open an issue for any reason as long as you make it clear if the issue is about a bug/feature/question/comment.
+- Please spend some time giving due diligence to the issue tracker. Your issue might be a duplicate. If it is, please add your comment to the existing issue.
+- Remember, users might be searching for your issue in the future. So please give it a meaningful title to help others.
+- The issue should clearly explain the reason for opening the proposal if you have any, along with any relevant technical information.
+- For questions and bug reports, please include the output you're seeing (using debug logging where possible) and describe what is different from what you expected to see.
+
+## Pull Requests
+
+1. Every Pull Request should have an associated Issue, unless you are fixing a trivial documentation issue.
+1. We will not accept changes to LICENSE, NOTICE or CONTRIBUTING from outside the Aqua Security team. Please raise an Issue if you believe there is a problem with any of these files. 
+1. Your PR is more likely to be accepted if it focuses on just one change.
+1. Describe what the PR does. There's no convention enforced, but please try to be concise and descriptive. Treat the PR description as a commit message. Titles that start with "fix"/"add"/"improve"/"remove" are good examples.
+1. Please add the associated Issue in the PR description.
+1. Please include a comment with the results before and after your change.
+1. There's no need to add or tag reviewers.
+1. If a reviewer commented on your code or asked for changes, please remember to mark the discussion as resolved after you address it. PRs with unresolved issues should not be merged (even if the comment is unclear or requires no action from your side).
+1. Your PR is more likely to be accepted if it includes tests.


### PR DESCRIPTION
This gets shown by default for projects that don’t have their own Contributing file. 

Ideally we’d find a way to avoid duplicating information between this global version and the project-specific ones, but I think this is a step in the right direction